### PR TITLE
Replace deprecated gulp-util dependency

### DIFF
--- a/lib/gm.js
+++ b/lib/gm.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var async = require('async');
 var gm = require('gm');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var path = require('path');
 var rename = require('rename');
 
@@ -92,7 +92,7 @@ module.exports = function (file, options, callback) {
           }));
         }
 
-        var newFile = new gutil.File({
+        var newFile = new Vinyl({
           cwd: file.cwd,
           base: file.base,
           path: filePath,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "gm": "^1.18.1",
-    "gulp-util": "^3.0.6",
+    "vinyl": "^2.2.0",
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "rename": "^1.0.3",


### PR DESCRIPTION
Replace deprecated gulp-util following guidance at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5, suggesting replacing `gutil.File` with `Vinyl`.